### PR TITLE
fix: `subItembyid` to  `subItemID`

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -80,7 +80,7 @@ RegisterServerEvent('syn_miner_lumber:removeitem')
 AddEventHandler('syn_miner_lumber:removeitem', function(item,itemdata)
 	local _source = source
     local id = itemdata.item.mainid
-    exports.vorp_inventory:subItemById(_source, id, nil)
+    exports.vorp_inventory:subItemId(_source, id, nil)
     VorpCore.NotifyRightTip( _source, language.axebroken, 2000)
 end)
 


### PR DESCRIPTION
` subItembyid` was wrong in the vorp Docs back then and was changed on my fork but never pushed not sure why